### PR TITLE
Scikit-learn f1_score changes default from weighted to binary in 0.17…

### DIFF
--- a/src/utilities/fitness/error_metric.py
+++ b/src/utilities/fitness/error_metric.py
@@ -92,6 +92,6 @@ def f1_score(y, yhat):
         # undefined, and sklearn will give a runtime warning and
         # return 0. We can ignore that warning and happily return 0.
         warnings.simplefilter("ignore")
-        return sklearn_f1_score(y, yhat)
+        return sklearn_f1_score(y, yhat, average="weighted")
 # Set maximise attribute for f1_score error metric.
 f1_score.maximise = True


### PR DESCRIPTION
… and then some aspect of error reporting in 0.19, which breaks our classification. Fix: set weighted explicitly rather than rely on default. Closes #86.